### PR TITLE
fix: disable fmt for api ref

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,2 @@
 /tests
+/res/API_REFERENCE.md

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -211,7 +211,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "changelog-gen"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "anyhow",
  "cached",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/wiiznokes/changelog-generator.git"
 
 [package]
 name = "changelog-gen"
-version = "0.1.6"
+version = "0.1.7"
 keywords = ["changelog", "release", "tool", "release-note"]
 description = "Helper program to manage a changelog"
 categories = ["development-tools"]

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ This project use `changelog-gen` to maintain its changelog, using github action
 > [!WARNING]  
 > All tags of the repo and versions in the changelog must follow the [semver](https://semver.org/) format. This may be relaxed in the future.
 
-**The full API reference can be found [here](./res/api_reference.md)** (automatically generated).
+**The full API reference can be found [here](./res/API_REFERENCE.md)** (automatically generated).
 
 ## Commit syntax
 

--- a/res/API_REFERENCE.md
+++ b/res/API_REFERENCE.md
@@ -20,7 +20,7 @@ Changelog generator
 ###### **Subcommands:**
 
 * `generate` — Generate release notes. By default, generate from the last release in the changelog to HEAD
-* `release` — Generate a new release. By default, use the last tag present in the repo, sorted using [semver](https://semver.org/) format
+* `release` — Generate a new release. By default, use the last tag present in the repo, sorted using the [semver](https://semver.org/) format
 * `validate` — Validate a changelog syntax
 * `show` — Show a specific release on stdout
 * `new` — Create a new changelog file with an accepted syntax
@@ -51,7 +51,7 @@ Generate release notes. By default, generate from the last release in the change
 
   Default value: `github`
 
-  Possible values: `github`, `other`
+  Possible values: `github`, `none`
 
 * `--repo <REPO>` — Needed for fetching PRs. Example: 'wiiznokes/changelog-generator'. Already defined for you in Github Actions.
 * `--omit-pr-link` — Omit the PR link from the output.
@@ -66,7 +66,7 @@ Generate release notes. By default, generate from the last release in the change
 
 ## `changelog release`
 
-Generate a new release. By default, use the last tag present in the repo, sorted using [semver](https://semver.org/) format
+Generate a new release. By default, use the last tag present in the repo, sorted using the [semver](https://semver.org/) format
 
 **Usage:** `changelog release [OPTIONS]`
 
@@ -81,7 +81,7 @@ Generate a new release. By default, use the last tag present in the repo, sorted
 
   Default value: `github`
 
-  Possible values: `github`, `other`
+  Possible values: `github`, `none`
 
 * `--repo <REPO>` — Needed for the tags diff PRs. Example: 'wiiznokes/changelog-generator'. Already defined for you in Github Actions.
 * `--omit-diff` — Omit the commit history between releases.

--- a/src/config.rs
+++ b/src/config.rs
@@ -183,7 +183,7 @@ pub struct Generate {
     pub until: Option<String>,
 }
 
-/// Generate a new release. By default, use the last tag present in the repo, sorted using the [semver](https://semver.org/) format. 
+/// Generate a new release. By default, use the last tag present in the repo, sorted using the [semver](https://semver.org/) format.
 #[derive(Args)]
 pub struct Release {
     #[arg(

--- a/src/gen_doc.rs
+++ b/src/gen_doc.rs
@@ -9,7 +9,7 @@ fn main() -> anyhow::Result<()> {
         .create(true)
         .truncate(true)
         .write(true)
-        .open("res/api_reference.md")?;
+        .open("res/API_REFERENCE.md")?;
 
     file.write_all(doc.as_bytes())?;
 


### PR DESCRIPTION
Please explain briefly what the PR does. It's not always obvious for maintainers.

Also, please check the case "allow edits by maintainers", this make it easy for maintainers to do a few commit before merging.

You also need to run `just pull` to format and check that all test will pass on CI.
